### PR TITLE
Fix for Django 2.2+

### DIFF
--- a/django_log_email/backends.py
+++ b/django_log_email/backends.py
@@ -9,7 +9,7 @@ class EmailBackend(ConsoleEmailBackend):
         log_file = getattr(settings, 'EMAIL_LOG_FILE', None)
         if not isinstance(log_file, str):
             raise ImproperlyConfigured('EMAIL_LOG_FILE is invalid: %r' % log_file)
-        stream = open(log_file, 'ab')
+        stream = open(log_file, 'a')
         super(EmailBackend, self).__init__(*args, **dict(kwargs, stream=stream))
         self.backend = None
         backend_name = getattr(settings, 'EMAIL_LOG_BACKEND', None)


### PR DESCRIPTION
Running on Django 2.2 (and I presume later), mail.backends writes str data to the provided stream which crashes because a byte stream is provided here. I presume as this repo has not been touched in 4 years it's simply not kept up with Django ... which is now at v3.1.